### PR TITLE
debug: Add temporary logging for load verification

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from bot.config import DISCORD_BOT_TOKEN, log
 from bot.discord_bot import bot
-from bot.checkin_store import USER_LINKS, load_linked_players # Import load_linked_players
+from bot.checkin_store import USER_LINKS, load_linked_players
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Main Bot Execution
@@ -26,6 +26,7 @@ async def main():
     # Load linked players from persistent storage on startup
     loaded_users = load_linked_players()
     USER_LINKS.update(loaded_users)
+    log.info(f"Loaded USER_LINKS on startup: {USER_LINKS}") # Temporary logging for validation
 
     try:
         await bot.start(DISCORD_BOT_TOKEN)


### PR DESCRIPTION
This commit introduces a temporary log statement in `main.py` to display the contents of `USER_LINKS` after loading from persistent storage. This is for immediate verification that the `load_linked_players` function is correctly populating the dictionary on bot startup.

This logging statement is for debugging purposes and should be removed after verification is complete.