### PR TITLE
fix: importer error for browser config

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -28,6 +28,12 @@ DISCORD_BOT_TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 # Set to 'True' or 'False' in the .env file. Defaults to True if not specified.
 OAUTH_LOGIN_ENABLED = os.getenv('OAUTH_LOGIN_ENABLED', 'True').lower() == 'true'
 
+EAGLE_EMAIL = os.getenv('EAGLE_EMAIL')
+EAGLE_PASSWORD = os.getenv('EAGLE_PASSWORD')
+CHROME_DRIVER_PATH = os.getenv('CHROME_DRIVER_PATH')
+CHROME_USER_DATA_DIR = os.getenv('CHROME_USER_DATA_DIR')
+CHROME_PROFILE_DIR = os.getenv('CHROME_PROFILE_DIR')
+
 # Example: Base URL for Eagle's SDVX profile pages
 # SDVX_PROFILE_BASE_URL = "https://eagle.ac/game/sdvx/profile/"
 


### PR DESCRIPTION
This commit resolves the ImportError for EAGLE_EMAIL, EAGLE_PASSWORD, and other eagle_browser related constants by adding them to bot/config.py. These constants are now loaded from environment variables via the .env file for secure handling of sensitive information.

This addresses the immediate blocker preventing bot startup after the introduction of conditional OAuth login logic, which exposed these pre-existing dependencies of eagle_browser.py.